### PR TITLE
Improve performance by memoizing components

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,5 @@
       "last 1 safari version"
     ]
   },
-  "devDependencies": {
-    "@types/lodash": "^4.14.169"
-  }
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^12.20.11",
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.3",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
@@ -41,5 +42,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.169"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@types/node": "^12.20.11",
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.3",
-    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
     (operatorName: string, property: string, value: number | boolean) => {
       setOperators((oldOperators) => {
         const copyOperators = { ...oldOperators };
-        const copyOperatorData = copyOperators[operatorName];
+        const copyOperatorData = { ...copyOperators[operatorName] };
         (copyOperatorData as any)[property] = value;
         copyOperators[operatorName] = copyOperatorData;
         return copyOperators;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,19 +58,18 @@ function App() {
     )
   );
 
-  const handleChange = (
-    operatorName: string,
-    property: string,
-    value: number | boolean
-  ) => {
-    setOperators((oldOperators) => {
-      const copyOperators = { ...oldOperators };
-      const copyOperatorData = copyOperators[operatorName];
-      (copyOperatorData as any)[property] = value;
-      copyOperators[operatorName] = copyOperatorData;
-      return copyOperators;
-    });
-  };
+  const handleChange = React.useCallback(
+    (operatorName: string, property: string, value: number | boolean) => {
+      setOperators((oldOperators) => {
+        const copyOperators = { ...oldOperators };
+        const copyOperatorData = copyOperators[operatorName];
+        (copyOperatorData as any)[property] = value;
+        copyOperators[operatorName] = copyOperatorData;
+        return copyOperators;
+      });
+    },
+    []
+  );
 
   // no clue what this is for
   function a11yProps(index: number) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,24 +4,22 @@ import {
   Box,
   createMuiTheme,
   CssBaseline,
-  Grid,
   Tab,
   Tabs,
   ThemeProvider,
   Typography,
 } from "@material-ui/core";
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
+import Table from "@material-ui/core/Table";
+import TableHead from "@material-ui/core/TableHead";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableRow from "@material-ui/core/TableRow";
 import "./App.css";
 
 import OperatorDataTableRow from "./components/OperatorDataTableRow";
 import operatorJson from "./data/operators.json";
 import OpForm from "./components/OpForm";
 import OperatorCollectionBlock from "./components/OperatorCollectionBlock";
-
 
 const darkTheme = createMuiTheme({
   palette: {
@@ -30,23 +28,23 @@ const darkTheme = createMuiTheme({
 });
 
 export interface Operator {
- name : string;
- rarity : number;
- potential : number;
- promotion : number;
- owned: boolean;
- level : number;
- skillLevel : number;
- skill1Mastery?: number;
- skill2Mastery?: number;
- skill3Mastery?: number;
+  name: string;
+  rarity: number;
+  potential: number;
+  promotion: number;
+  owned: boolean;
+  level: number;
+  skillLevel: number;
+  skill1Mastery?: number;
+  skill2Mastery?: number;
+  skill3Mastery?: number;
 }
 
 function App() {
   const [operators, setOperators] = useState<Record<string, Operator>>(
     Object.fromEntries(
       operatorJson.map((op) => [
-        op.name, 
+        op.name,
         {
           name: op.name,
           rarity: op.rarity,
@@ -54,34 +52,37 @@ function App() {
           potential: 0,
           promotion: 0,
           level: 0,
-          skillLevel: 0
-          }]))
+          skillLevel: 0,
+        },
+      ])
+    )
   );
 
   const handleChange = (
     operatorName: string,
     property: string,
-    value: number | boolean) => {
-      const copyOperators = {...operators};
-      const operatorData = copyOperators[operatorName];
-      (operatorData as any)[property] = value;
-      setOperators(copyOperators);
+    value: number | boolean
+  ) => {
+    const copyOperators = { ...operators };
+    const operatorData = copyOperators[operatorName];
+    (operatorData as any)[property] = value;
+    setOperators(copyOperators);
   };
 
   // no clue what this is for
-  function a11yProps(index : number) {
+  function a11yProps(index: number) {
     return {
       id: `simple-tab-${index}`,
-      "aria-controls": `simple-tabpanel-${index}`
+      "aria-controls": `simple-tabpanel-${index}`,
     };
   }
-  
+
   // operator name search filter
   const [operatorFilter, setOperatorFilter] = useState<string>("");
 
   // tab value controller
   const [value, setValue] = React.useState(0);
-  const handleTabChange = (event : any, newValue : number) => {
+  const handleTabChange = (event: any, newValue: number) => {
     setValue(newValue);
   };
 
@@ -89,14 +90,18 @@ function App() {
     <ThemeProvider theme={darkTheme}>
       <CssBaseline />
       <AppBar position="static">
-        <Tabs value={value} onChange={handleTabChange} aria-label="simple tabs example">
-        <Tab label="Roster" {...a11yProps(0)} />
-        <Tab label="Collection" {...a11yProps(1)} />
-        <Tab label="Placeholder" {...a11yProps(2)} />
-      </Tabs>
+        <Tabs
+          value={value}
+          onChange={handleTabChange}
+          aria-label="simple tabs example"
+        >
+          <Tab label="Roster" {...a11yProps(0)} />
+          <Tab label="Collection" {...a11yProps(1)} />
+          <Tab label="Placeholder" {...a11yProps(2)} />
+        </Tabs>
       </AppBar>
       <TabPanel value={value} index={0}>
-        <OpForm onChange={setOperatorFilter}/>
+        <OpForm onChange={setOperatorFilter} />
         <Table>
           <TableHead>
             <TableRow>
@@ -141,13 +146,12 @@ function App() {
         </div>
       </TabPanel>
     </ThemeProvider>
-  )
+  );
 }
 
 export default App;
 
-
-function TabPanel(props : TabProps) {
+function TabPanel(props: TabProps) {
   const { children, value, index, ...other } = props;
 
   return (
@@ -168,7 +172,7 @@ function TabPanel(props : TabProps) {
 }
 
 interface TabProps {
-  children: any,
-  index: number,
-  value: number
-};
+  children: any;
+  index: number;
+  value: number;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,11 +63,13 @@ function App() {
     property: string,
     value: number | boolean
   ) => {
-    const copyOperators = { ...operators };
-    const copyOperatorData = copyOperators[operatorName];
-    (copyOperatorData as any)[property] = value;
-    copyOperators[operatorName] = copyOperatorData;
-    setOperators(copyOperators);
+    setOperators((oldOperators) => {
+      const copyOperators = { ...oldOperators };
+      const copyOperatorData = copyOperators[operatorName];
+      (copyOperatorData as any)[property] = value;
+      copyOperators[operatorName] = copyOperatorData;
+      return copyOperators;
+    });
   };
 
   // no clue what this is for

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,29 +114,30 @@ function App() {
             </TableRow>
           </TableHead>
           <TableBody>
-            {operatorJson.map((op) =>
-              {
-                const opData = operators[op.name];
-                if (op.name.toLowerCase().includes(operatorFilter.toLowerCase())) {
-                  return <OperatorDataTableRow 
-                          operator={opData} 
-                          onChange = {handleChange} />;
-                }
-              })
-            }
+            {operatorJson
+              .filter((op) =>
+                op.name.toLowerCase().includes(operatorFilter.toLowerCase())
+              )
+              .map((op) => (
+                <OperatorDataTableRow
+                  key={op.name}
+                  operator={operators[op.name]}
+                  onChange={handleChange}
+                />
+              ))}
           </TableBody>
         </Table>
       </TabPanel>
       <TabPanel value={value} index={1}>
         <div className="container">
-          {operatorJson.map((op) =>
-            {
-              const opData = operators[op.name];
-              if (opData.potential > 0) {
-                return <OperatorCollectionBlock operator={opData}/>;
-              }
-            })
-          }
+          {operatorJson
+            .filter((op) => operators[op.name].potential > 0)
+            .map((op) => (
+              <OperatorCollectionBlock
+                key={op.name}
+                operator={operators[op.name]}
+              />
+            ))}
         </div>
       </TabPanel>
     </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,8 +64,9 @@ function App() {
     value: number | boolean
   ) => {
     const copyOperators = { ...operators };
-    const operatorData = copyOperators[operatorName];
-    (operatorData as any)[property] = value;
+    const copyOperatorData = copyOperators[operatorName];
+    (copyOperatorData as any)[property] = value;
+    copyOperators[operatorName] = copyOperatorData;
     setOperators(copyOperators);
   };
 

--- a/src/components/OperatorCollectionBlock.tsx
+++ b/src/components/OperatorCollectionBlock.tsx
@@ -29,7 +29,9 @@ function OperatorCollectionBlock(props: Props) {
         <div className="operator-name-large">{operator.name}</div>
       </div>
       <div className="collection-block-data-row">
-        <div className="collection-block-member">{"⭐".repeat(operator.rarity)}</div>
+        <div className="collection-block-member">
+          {"⭐".repeat(operator.rarity)}
+        </div>
       </div>
       <div className="collection-block-data-row">
         <div className="collection-block-member">
@@ -52,13 +54,21 @@ function OperatorCollectionBlock(props: Props) {
       </div>
       {operator.skillLevel < 7 ? (
         <div className="collection-block-data-row">
-          <div className="collection-block-member">Skill Level {operator.skillLevel}</div>
+          <div className="collection-block-member">
+            Skill Level {operator.skillLevel}
+          </div>
         </div>
       ) : (
         <div className="collection-block-data-row">
-          <div className="collection-block-member">{operator.skill1Mastery}</div>
-          <div className="collection-block-member">{operator.skill2Mastery}</div>
-          <div className="collection-block-member">{operator.skill3Mastery}</div>
+          <div className="collection-block-member">
+            {operator.skill1Mastery}
+          </div>
+          <div className="collection-block-member">
+            {operator.skill2Mastery}
+          </div>
+          <div className="collection-block-member">
+            {operator.skill3Mastery}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/OperatorCollectionBlock.tsx
+++ b/src/components/OperatorCollectionBlock.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { isEqual } from "lodash";
 import slugify from "slugify";
 import { Operator } from "../App";
 
@@ -7,76 +6,73 @@ interface Props {
   operator: Operator;
 }
 
-const OperatorCollectionBlock = React.memo(
-  (props: Props) => {
-    const { operator } = props;
-    const potentialUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/potential/${operator.potential}`;
-    const promotionUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/elite/${operator.promotion}`;
+const OperatorCollectionBlock = React.memo((props: Props) => {
+  const { operator } = props;
+  const potentialUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/potential/${operator.potential}`;
+  const promotionUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/elite/${operator.promotion}`;
 
-    let intermediate = operator.name;
-    if (operator.promotion === 2) {
-      intermediate += " elite 2";
-    } else if (operator.promotion === 1 && operator.name === "Amiya") {
-      intermediate += " elite 1";
-    }
+  let intermediate = operator.name;
+  if (operator.promotion === 2) {
+    intermediate += " elite 2";
+  } else if (operator.promotion === 1 && operator.name === "Amiya") {
+    intermediate += " elite 1";
+  }
 
-    const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
-      intermediate,
-      { lower: true, replacement: "-" }
-    )}`;
+  const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
+    intermediate,
+    { lower: true, replacement: "-" }
+  )}`;
 
-    return (
-      <div className="collection-block">
-        <img src={imgUrl} alt={operator.name} />
-        <div className="collection-block-data-row">
-          <div className="operator-name-large">{operator.name}</div>
-        </div>
-        <div className="collection-block-data-row">
-          <div className="collection-block-member">
-            {"⭐".repeat(operator.rarity)}
-          </div>
-        </div>
-        <div className="collection-block-data-row">
-          <div className="collection-block-member">
-            <img
-              src={potentialUrl}
-              className="collection-block-icon"
-              alt={`Potential ${operator.potential} icon`}
-            />
-          </div>
-          <div className="collection-block-member">
-            <img
-              src={promotionUrl}
-              className="collection-block-icon"
-              alt={`Elite ${operator.promotion} icon`}
-            />
-          </div>
-          <div className="collection-block-member">
-            <div className="collection-block-level-large">{operator.level}</div>
-          </div>
-        </div>
-        {operator.skillLevel < 7 ? (
-          <div className="collection-block-data-row">
-            <div className="collection-block-member">
-              Skill Level {operator.skillLevel}
-            </div>
-          </div>
-        ) : (
-          <div className="collection-block-data-row">
-            <div className="collection-block-member">
-              {operator.skill1Mastery}
-            </div>
-            <div className="collection-block-member">
-              {operator.skill2Mastery}
-            </div>
-            <div className="collection-block-member">
-              {operator.skill3Mastery}
-            </div>
-          </div>
-        )}
+  return (
+    <div className="collection-block">
+      <img src={imgUrl} alt={operator.name} />
+      <div className="collection-block-data-row">
+        <div className="operator-name-large">{operator.name}</div>
       </div>
-    );
-  },
-  (prevProps, nextProps) => isEqual(prevProps.operator, nextProps.operator)
-);
+      <div className="collection-block-data-row">
+        <div className="collection-block-member">
+          {"⭐".repeat(operator.rarity)}
+        </div>
+      </div>
+      <div className="collection-block-data-row">
+        <div className="collection-block-member">
+          <img
+            src={potentialUrl}
+            className="collection-block-icon"
+            alt={`Potential ${operator.potential} icon`}
+          />
+        </div>
+        <div className="collection-block-member">
+          <img
+            src={promotionUrl}
+            className="collection-block-icon"
+            alt={`Elite ${operator.promotion} icon`}
+          />
+        </div>
+        <div className="collection-block-member">
+          <div className="collection-block-level-large">{operator.level}</div>
+        </div>
+      </div>
+      {operator.skillLevel < 7 ? (
+        <div className="collection-block-data-row">
+          <div className="collection-block-member">
+            Skill Level {operator.skillLevel}
+          </div>
+        </div>
+      ) : (
+        <div className="collection-block-data-row">
+          <div className="collection-block-member">
+            {operator.skill1Mastery}
+          </div>
+          <div className="collection-block-member">
+            {operator.skill2Mastery}
+          </div>
+          <div className="collection-block-member">
+            {operator.skill3Mastery}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
 export default OperatorCollectionBlock;

--- a/src/components/OperatorCollectionBlock.tsx
+++ b/src/components/OperatorCollectionBlock.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { isEqual } from "lodash";
 import slugify from "slugify";
 import { Operator } from "../App";
 
@@ -5,73 +7,76 @@ interface Props {
   operator: Operator;
 }
 
-function OperatorCollectionBlock(props: Props) {
-  const { operator } = props;
-  const potentialUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/potential/${operator.potential}`;
-  const promotionUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/elite/${operator.promotion}`;
+const OperatorCollectionBlock = React.memo(
+  (props: Props) => {
+    const { operator } = props;
+    const potentialUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/potential/${operator.potential}`;
+    const promotionUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/elite/${operator.promotion}`;
 
-  let intermediate = operator.name;
-  if (operator.promotion === 2) {
-    intermediate += " elite 2";
-  } else if (operator.promotion === 1 && operator.name === "Amiya") {
-    intermediate += " elite 1";
-  }
+    let intermediate = operator.name;
+    if (operator.promotion === 2) {
+      intermediate += " elite 2";
+    } else if (operator.promotion === 1 && operator.name === "Amiya") {
+      intermediate += " elite 1";
+    }
 
-  const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
-    intermediate,
-    { lower: true, replacement: "-" }
-  )}`;
+    const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
+      intermediate,
+      { lower: true, replacement: "-" }
+    )}`;
 
-  return (
-    <div className="collection-block">
-      <img src={imgUrl} alt={operator.name} />
-      <div className="collection-block-data-row">
-        <div className="operator-name-large">{operator.name}</div>
-      </div>
-      <div className="collection-block-data-row">
-        <div className="collection-block-member">
-          {"⭐".repeat(operator.rarity)}
+    return (
+      <div className="collection-block">
+        <img src={imgUrl} alt={operator.name} />
+        <div className="collection-block-data-row">
+          <div className="operator-name-large">{operator.name}</div>
         </div>
-      </div>
-      <div className="collection-block-data-row">
-        <div className="collection-block-member">
-          <img
-            src={potentialUrl}
-            className="collection-block-icon"
-            alt={`Potential ${operator.potential} icon`}
-          />
-        </div>
-        <div className="collection-block-member">
-          <img
-            src={promotionUrl}
-            className="collection-block-icon"
-            alt={`Elite ${operator.promotion} icon`}
-          />
-        </div>
-        <div className="collection-block-member">
-          <div className="collection-block-level-large">{operator.level}</div>
-        </div>
-      </div>
-      {operator.skillLevel < 7 ? (
         <div className="collection-block-data-row">
           <div className="collection-block-member">
-            Skill Level {operator.skillLevel}
+            {"⭐".repeat(operator.rarity)}
           </div>
         </div>
-      ) : (
         <div className="collection-block-data-row">
           <div className="collection-block-member">
-            {operator.skill1Mastery}
+            <img
+              src={potentialUrl}
+              className="collection-block-icon"
+              alt={`Potential ${operator.potential} icon`}
+            />
           </div>
           <div className="collection-block-member">
-            {operator.skill2Mastery}
+            <img
+              src={promotionUrl}
+              className="collection-block-icon"
+              alt={`Elite ${operator.promotion} icon`}
+            />
           </div>
           <div className="collection-block-member">
-            {operator.skill3Mastery}
+            <div className="collection-block-level-large">{operator.level}</div>
           </div>
         </div>
-      )}
-    </div>
-  );
-}
+        {operator.skillLevel < 7 ? (
+          <div className="collection-block-data-row">
+            <div className="collection-block-member">
+              Skill Level {operator.skillLevel}
+            </div>
+          </div>
+        ) : (
+          <div className="collection-block-data-row">
+            <div className="collection-block-member">
+              {operator.skill1Mastery}
+            </div>
+            <div className="collection-block-member">
+              {operator.skill2Mastery}
+            </div>
+            <div className="collection-block-member">
+              {operator.skill3Mastery}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+  (prevProps, nextProps) => isEqual(prevProps.operator, nextProps.operator)
+);
 export default OperatorCollectionBlock;

--- a/src/components/OperatorDataTableRow.tsx
+++ b/src/components/OperatorDataTableRow.tsx
@@ -3,7 +3,6 @@ import slugify from "slugify";
 import { Operator } from "../App";
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
-import { isEqual } from "lodash";
 
 interface Props {
   operator: Operator;
@@ -14,138 +13,129 @@ interface Props {
   ) => void;
 }
 
-const OperatorDataTableRow = React.memo(
-  (props: Props) => {
-    const { operator, onChange } = props;
+const OperatorDataTableRow = React.memo((props: Props) => {
+  const { operator, onChange } = props;
 
-    let intermediate = operator.name;
-    if (operator.promotion === 2) {
-      intermediate += " elite 2";
-    } else if (operator.promotion === 1 && operator.name === "Amiya") {
-      intermediate += " elite 1";
-    }
+  let intermediate = operator.name;
+  if (operator.promotion === 2) {
+    intermediate += " elite 2";
+  } else if (operator.promotion === 1 && operator.name === "Amiya") {
+    intermediate += " elite 1";
+  }
 
-    const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
-      intermediate,
-      { lower: true, replacement: "-" }
-    )}`;
+  const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
+    intermediate,
+    { lower: true, replacement: "-" }
+  )}`;
 
-    return (
-      <TableRow key={operator.name}>
-        <TableCell align="right">
-          <input
-            name="owned"
-            type="checkbox"
-            checked={operator.owned}
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.checked)
-            }
-          />
-        </TableCell>
-        <TableCell align="right">
-          <img
-            style={{ opacity: operator.owned ? 1 : 0.2 }}
-            className="table-icon-small"
-            src={imgUrl}
-            alt={operator.name}
-          />
-        </TableCell>
-        <TableCell>{operator.rarity}</TableCell>
-        <TableCell component="th" scope="row">
-          {operator.name}
-        </TableCell>
-        <TableCell align="right">
-          <input
-            name="potential"
-            type="number"
-            value={operator.potential}
-            disabled={!operator.owned}
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.valueAsNumber)
-            }
-          />
-        </TableCell>
-        <TableCell align="right">
-          <input
-            name="promotion"
-            type="number"
-            value={operator.promotion}
-            disabled={!operator.owned}
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.valueAsNumber)
-            }
-          />
-        </TableCell>
-        <TableCell align="right">
-          <input
-            name="level"
-            type="number"
-            value={operator.level}
-            disabled={!operator.owned}
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.valueAsNumber)
-            }
-          />
-        </TableCell>
-        <TableCell align="right">
-          <input
-            name="skillLevel"
-            type="number"
-            value={operator.skillLevel}
-            disabled={!operator.owned}
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.valueAsNumber)
-            }
-          />
-        </TableCell>
-        <TableCell align="right">
-          <input
-            name="skill1Mastery"
-            type="number"
-            value={operator.skill1Mastery}
-            disabled={
-              operator.promotion < 2 ||
-              operator.skillLevel < 7 ||
-              !operator.owned
-            }
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.valueAsNumber)
-            }
-          />
-        </TableCell>
-        <TableCell align="right">
-          <input
-            name="skill2Mastery"
-            type="number"
-            value={operator.skill2Mastery}
-            disabled={
-              operator.promotion < 2 ||
-              operator.skillLevel < 7 ||
-              !operator.owned
-            }
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.valueAsNumber)
-            }
-          />
-        </TableCell>
-        <TableCell align="right">
-          <input
-            name="skill3Mastery"
-            type="number"
-            value={operator.skill3Mastery}
-            disabled={
-              operator.promotion < 2 ||
-              operator.skillLevel < 7 ||
-              !operator.owned
-            }
-            onChange={(e) =>
-              onChange(operator.name, e.target.name, e.target.valueAsNumber)
-            }
-          />
-        </TableCell>
-      </TableRow>
-    );
-  },
-  (prevProps, nextProps) => isEqual(prevProps.operator, nextProps.operator)
-);
+  return (
+    <TableRow key={operator.name}>
+      <TableCell align="right">
+        <input
+          name="owned"
+          type="checkbox"
+          checked={operator.owned}
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.checked)
+          }
+        />
+      </TableCell>
+      <TableCell align="right">
+        <img
+          style={{ opacity: operator.owned ? 1 : 0.2 }}
+          className="table-icon-small"
+          src={imgUrl}
+          alt={operator.name}
+        />
+      </TableCell>
+      <TableCell>{operator.rarity}</TableCell>
+      <TableCell component="th" scope="row">
+        {operator.name}
+      </TableCell>
+      <TableCell align="right">
+        <input
+          name="potential"
+          type="number"
+          value={operator.potential}
+          disabled={!operator.owned}
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
+        />
+      </TableCell>
+      <TableCell align="right">
+        <input
+          name="promotion"
+          type="number"
+          value={operator.promotion}
+          disabled={!operator.owned}
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
+        />
+      </TableCell>
+      <TableCell align="right">
+        <input
+          name="level"
+          type="number"
+          value={operator.level}
+          disabled={!operator.owned}
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
+        />
+      </TableCell>
+      <TableCell align="right">
+        <input
+          name="skillLevel"
+          type="number"
+          value={operator.skillLevel}
+          disabled={!operator.owned}
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
+        />
+      </TableCell>
+      <TableCell align="right">
+        <input
+          name="skill1Mastery"
+          type="number"
+          value={operator.skill1Mastery}
+          disabled={
+            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
+          }
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
+        />
+      </TableCell>
+      <TableCell align="right">
+        <input
+          name="skill2Mastery"
+          type="number"
+          value={operator.skill2Mastery}
+          disabled={
+            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
+          }
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
+        />
+      </TableCell>
+      <TableCell align="right">
+        <input
+          name="skill3Mastery"
+          type="number"
+          value={operator.skill3Mastery}
+          disabled={
+            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
+          }
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
+        />
+      </TableCell>
+    </TableRow>
+  );
+});
 export default OperatorDataTableRow;

--- a/src/components/OperatorDataTableRow.tsx
+++ b/src/components/OperatorDataTableRow.tsx
@@ -1,17 +1,21 @@
 import React from "react";
 import slugify from "slugify";
 import { Operator } from "../App";
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
+import TableCell from "@material-ui/core/TableCell";
+import TableRow from "@material-ui/core/TableRow";
 
 interface Props {
   operator: Operator;
-  onChange: (operatorName: string, property: string, value: number | boolean) => void;
+  onChange: (
+    operatorName: string,
+    property: string,
+    value: number | boolean
+  ) => void;
 }
 
 function OperatorDataTableRow(props: Props) {
   const { operator, onChange } = props;
-  
+
   let intermediate = operator.name;
   if (operator.promotion === 2) {
     intermediate += " elite 2";
@@ -27,85 +31,108 @@ function OperatorDataTableRow(props: Props) {
   return (
     <TableRow key={operator.name}>
       <TableCell align="right">
-        <input 
+        <input
           name="owned"
-          type="checkbox" 
+          type="checkbox"
           checked={operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.checked)}
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.checked)
+          }
         />
       </TableCell>
       <TableCell align="right">
         <img
-          style={{opacity :  (operator.owned ? 1 : 0.2)}}
-          className="table-icon-small" 
-          src={imgUrl} 
-          alt={operator.name} />
+          style={{ opacity: operator.owned ? 1 : 0.2 }}
+          className="table-icon-small"
+          src={imgUrl}
+          alt={operator.name}
+        />
       </TableCell>
       <TableCell>{operator.rarity}</TableCell>
       <TableCell component="th" scope="row">
         {operator.name}
       </TableCell>
       <TableCell align="right">
-        <input 
+        <input
           name="potential"
           type="number"
           value={operator.potential}
           disabled={!operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.valueAsNumber)} 
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
         />
       </TableCell>
       <TableCell align="right">
-        <input 
+        <input
           name="promotion"
           type="number"
           value={operator.promotion}
           disabled={!operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.valueAsNumber)} 
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
         />
       </TableCell>
       <TableCell align="right">
-        <input 
+        <input
           name="level"
           type="number"
           value={operator.level}
           disabled={!operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.valueAsNumber)} 
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
         />
       </TableCell>
       <TableCell align="right">
-        <input 
+        <input
           name="skillLevel"
           type="number"
           value={operator.skillLevel}
           disabled={!operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.valueAsNumber)} 
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
         />
       </TableCell>
       <TableCell align="right">
-        <input 
+        <input
           name="skill1Mastery"
           type="number"
           value={operator.skill1Mastery}
-          disabled={operator.promotion<2 || operator.skillLevel<7 || !operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.valueAsNumber)} 
+          disabled={
+            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
+          }
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
         />
       </TableCell>
       <TableCell align="right">
-        <input 
+        <input
           name="skill2Mastery"
           type="number"
           value={operator.skill2Mastery}
-          disabled={operator.promotion<2 || operator.skillLevel<7 || !operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.valueAsNumber)} 
+          disabled={
+            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
+          }
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
         />
       </TableCell>
       <TableCell align="right">
-        <input 
+        <input
           name="skill3Mastery"
           type="number"
           value={operator.skill3Mastery}
-          disabled={operator.promotion<2 || operator.skillLevel<7 || !operator.owned}
-          onChange={(e) => onChange(operator.name, e.target.name, e.target.valueAsNumber)} 
+          disabled={
+            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
+          }
+          onChange={(e) =>
+            onChange(operator.name, e.target.name, e.target.valueAsNumber)
+          }
         />
       </TableCell>
     </TableRow>

--- a/src/components/OperatorDataTableRow.tsx
+++ b/src/components/OperatorDataTableRow.tsx
@@ -3,6 +3,7 @@ import slugify from "slugify";
 import { Operator } from "../App";
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
+import { isEqual } from "lodash";
 
 interface Props {
   operator: Operator;
@@ -13,129 +14,138 @@ interface Props {
   ) => void;
 }
 
-function OperatorDataTableRow(props: Props) {
-  const { operator, onChange } = props;
+const OperatorDataTableRow = React.memo(
+  (props: Props) => {
+    const { operator, onChange } = props;
 
-  let intermediate = operator.name;
-  if (operator.promotion === 2) {
-    intermediate += " elite 2";
-  } else if (operator.promotion === 1 && operator.name === "Amiya") {
-    intermediate += " elite 1";
-  }
+    let intermediate = operator.name;
+    if (operator.promotion === 2) {
+      intermediate += " elite 2";
+    } else if (operator.promotion === 1 && operator.name === "Amiya") {
+      intermediate += " elite 1";
+    }
 
-  const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
-    intermediate,
-    { lower: true, replacement: "-" }
-  )}`;
+    const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
+      intermediate,
+      { lower: true, replacement: "-" }
+    )}`;
 
-  return (
-    <TableRow key={operator.name}>
-      <TableCell align="right">
-        <input
-          name="owned"
-          type="checkbox"
-          checked={operator.owned}
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.checked)
-          }
-        />
-      </TableCell>
-      <TableCell align="right">
-        <img
-          style={{ opacity: operator.owned ? 1 : 0.2 }}
-          className="table-icon-small"
-          src={imgUrl}
-          alt={operator.name}
-        />
-      </TableCell>
-      <TableCell>{operator.rarity}</TableCell>
-      <TableCell component="th" scope="row">
-        {operator.name}
-      </TableCell>
-      <TableCell align="right">
-        <input
-          name="potential"
-          type="number"
-          value={operator.potential}
-          disabled={!operator.owned}
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.valueAsNumber)
-          }
-        />
-      </TableCell>
-      <TableCell align="right">
-        <input
-          name="promotion"
-          type="number"
-          value={operator.promotion}
-          disabled={!operator.owned}
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.valueAsNumber)
-          }
-        />
-      </TableCell>
-      <TableCell align="right">
-        <input
-          name="level"
-          type="number"
-          value={operator.level}
-          disabled={!operator.owned}
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.valueAsNumber)
-          }
-        />
-      </TableCell>
-      <TableCell align="right">
-        <input
-          name="skillLevel"
-          type="number"
-          value={operator.skillLevel}
-          disabled={!operator.owned}
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.valueAsNumber)
-          }
-        />
-      </TableCell>
-      <TableCell align="right">
-        <input
-          name="skill1Mastery"
-          type="number"
-          value={operator.skill1Mastery}
-          disabled={
-            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
-          }
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.valueAsNumber)
-          }
-        />
-      </TableCell>
-      <TableCell align="right">
-        <input
-          name="skill2Mastery"
-          type="number"
-          value={operator.skill2Mastery}
-          disabled={
-            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
-          }
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.valueAsNumber)
-          }
-        />
-      </TableCell>
-      <TableCell align="right">
-        <input
-          name="skill3Mastery"
-          type="number"
-          value={operator.skill3Mastery}
-          disabled={
-            operator.promotion < 2 || operator.skillLevel < 7 || !operator.owned
-          }
-          onChange={(e) =>
-            onChange(operator.name, e.target.name, e.target.valueAsNumber)
-          }
-        />
-      </TableCell>
-    </TableRow>
-  );
-}
+    return (
+      <TableRow key={operator.name}>
+        <TableCell align="right">
+          <input
+            name="owned"
+            type="checkbox"
+            checked={operator.owned}
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.checked)
+            }
+          />
+        </TableCell>
+        <TableCell align="right">
+          <img
+            style={{ opacity: operator.owned ? 1 : 0.2 }}
+            className="table-icon-small"
+            src={imgUrl}
+            alt={operator.name}
+          />
+        </TableCell>
+        <TableCell>{operator.rarity}</TableCell>
+        <TableCell component="th" scope="row">
+          {operator.name}
+        </TableCell>
+        <TableCell align="right">
+          <input
+            name="potential"
+            type="number"
+            value={operator.potential}
+            disabled={!operator.owned}
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.valueAsNumber)
+            }
+          />
+        </TableCell>
+        <TableCell align="right">
+          <input
+            name="promotion"
+            type="number"
+            value={operator.promotion}
+            disabled={!operator.owned}
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.valueAsNumber)
+            }
+          />
+        </TableCell>
+        <TableCell align="right">
+          <input
+            name="level"
+            type="number"
+            value={operator.level}
+            disabled={!operator.owned}
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.valueAsNumber)
+            }
+          />
+        </TableCell>
+        <TableCell align="right">
+          <input
+            name="skillLevel"
+            type="number"
+            value={operator.skillLevel}
+            disabled={!operator.owned}
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.valueAsNumber)
+            }
+          />
+        </TableCell>
+        <TableCell align="right">
+          <input
+            name="skill1Mastery"
+            type="number"
+            value={operator.skill1Mastery}
+            disabled={
+              operator.promotion < 2 ||
+              operator.skillLevel < 7 ||
+              !operator.owned
+            }
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.valueAsNumber)
+            }
+          />
+        </TableCell>
+        <TableCell align="right">
+          <input
+            name="skill2Mastery"
+            type="number"
+            value={operator.skill2Mastery}
+            disabled={
+              operator.promotion < 2 ||
+              operator.skillLevel < 7 ||
+              !operator.owned
+            }
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.valueAsNumber)
+            }
+          />
+        </TableCell>
+        <TableCell align="right">
+          <input
+            name="skill3Mastery"
+            type="number"
+            value={operator.skill3Mastery}
+            disabled={
+              operator.promotion < 2 ||
+              operator.skillLevel < 7 ||
+              !operator.owned
+            }
+            onChange={(e) =>
+              onChange(operator.name, e.target.name, e.target.valueAsNumber)
+            }
+          />
+        </TableCell>
+      </TableRow>
+    );
+  },
+  (prevProps, nextProps) => isEqual(prevProps.operator, nextProps.operator)
+);
 export default OperatorDataTableRow;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,11 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.169":
+  version "4.14.169"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.169.tgz#83c217688f07a4d9ef8f28a3ebd1d318f6ff4cbb"
+  integrity sha512-DvmZHoHTFJ8zhVYwCLWbQ7uAbYQEk52Ev2/ZiQ7Y7gQGeV9pjBqjnQpECMHfKS1rCYAhMI7LHVxwyZLZinJgdw==
+
 "@types/minimatch@*":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,11 +1876,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.169":
-  version "4.14.169"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.169.tgz#83c217688f07a4d9ef8f28a3ebd1d318f6ff4cbb"
-  integrity sha512-DvmZHoHTFJ8zhVYwCLWbQ7uAbYQEk52Ev2/ZiQ7Y7gQGeV9pjBqjnQpECMHfKS1rCYAhMI7LHVxwyZLZinJgdw==
-
 "@types/minimatch@*":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"


### PR DESCRIPTION
This PR adds memoization for `<OperatorDataTableRow />` and `<OperatorCollectionBlock />`.

Currently performance on the Roster page is slow when checking a checkbox or editing an input. This is because React rerenders **every** operator in the tab when an input is changed. This occurs for two reasons:
- There is no `key` specified for the `<OperatorDataTableRow>` components.
- The components are not declared as pure components (using `React.memo`).

Obviously we only want to rerender the operator row that *actually changed*, i.e. the row that contains the control we just edited. So we need to do both of those things above.

There's a subtle bug in `main` regarding `handleChange` that breaks `React.memo`, but that has been fixed in this PR. 