### PR TITLE
Fix slugify function for Dur-nar

### DIFF
--- a/src/components/OperatorCollectionBlock.tsx
+++ b/src/components/OperatorCollectionBlock.tsx
@@ -20,7 +20,7 @@ const OperatorCollectionBlock = React.memo((props: Props) => {
 
   const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
     intermediate,
-    { lower: true, replacement: "-" }
+    { lower: true, replacement: "-", remove: /-/g }
   )}`;
 
   return (

--- a/src/components/OperatorDataTableRow.tsx
+++ b/src/components/OperatorDataTableRow.tsx
@@ -25,7 +25,7 @@ const OperatorDataTableRow = React.memo((props: Props) => {
 
   const imgUrl = `https://res.cloudinary.com/samidare/image/upload/v1/arknights/operators/${slugify(
     intermediate,
-    { lower: true, replacement: "-" }
+    { lower: true, replacement: "-", remove: /-/g }
   )}`;
 
   return (


### PR DESCRIPTION
The slugify function currently returns `"dur-nar"` for Dur-nar, but the actual image is located at `.../durnar` (no hyphen). This is why the image link is currently broken in the main branch.

We need to strip out hyphens as part of the slugify options.