### PR TITLE
Update operators.json

### DIFF
--- a/src/data/operators.json
+++ b/src/data/operators.json
@@ -1,927 +1,1184 @@
 [
   {
+    "id": "char_002_amiya",
     "name": "Amiya",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_003_kalts",
     "name": "Kal'tsit",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_009_12fce",
+    "name": "12F",
+    "isCnOnly": false,
+    "rarity": 2
+  },
+  {
+    "id": "char_010_chen",
     "name": "Ch'en",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_017_huang",
     "name": "Blaze",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_101_sora",
     "name": "Sora",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_1011_lava2",
     "name": "Lava the Purgatory",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_1012_skadi2",
     "name": "Skadi the Corrupting Heart",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_102_texas",
     "name": "Texas",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_103_angel",
     "name": "Exusiai",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_106_franka",
     "name": "Franka",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_107_liskam",
     "name": "Liskarm",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_108_silent",
     "name": "Silence",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_109_fmout",
     "name": "Gitano",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_110_deepcl",
     "name": "Deepcolor",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_112_siege",
     "name": "Siege",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_113_cqbw",
     "name": "W",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_115_headbr",
     "name": "Zima",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_117_myrrh",
     "name": "Myrrh",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_118_yuki",
     "name": "Shirayuki",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_120_hibisc",
     "name": "Hibiscus",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_121_lava",
     "name": "Lava",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_122_beagle",
     "name": "Beagle",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_123_fang",
     "name": "Fang",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_124_kroos",
     "name": "Kroos",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_126_shotst",
     "name": "Meteor",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_127_estell",
     "name": "Estelle",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_128_plosis",
     "name": "Ptilopsis",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_129_bluep",
     "name": "Blue Poison",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_130_doberm",
     "name": "Dobermann",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_131_flameb",
     "name": "Flamebringer",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_133_mm",
     "name": "May",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_134_ifrit",
     "name": "Ifrit",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_136_hsguma",
     "name": "Hoshiguma",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_137_brownb",
     "name": "Beehunter",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_140_whitew",
     "name": "Lappland",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_141_nights",
     "name": "Haze",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_143_ghost",
     "name": "Specter",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_144_red",
     "name": "Projekt Red",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_145_prove",
     "name": "Provence",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_147_shining",
     "name": "Shining",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_148_nearl",
     "name": "Nearl",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_149_scave",
     "name": "Scavenger",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_150_snakek",
     "name": "Cuora",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_151_myrtle",
     "name": "Myrtle",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_155_tiger",
     "name": "Indra",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_158_milu",
     "name": "Firewatch",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_159_peacok",
     "name": "Conviction",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_163_hpsts",
     "name": "Vulcan",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_164_nightm",
     "name": "Nightmare",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_166_skfire",
     "name": "Skyfire",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_171_bldsk",
     "name": "Warfarin",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_172_svrash",
     "name": "SilverAsh",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_173_slchan",
     "name": "Cliffheart",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_174_slbell",
     "name": "Pramanix",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_179_cgbird",
     "name": "Nightingale",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_180_amgoat",
     "name": "Eyjafjalla",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_181_flower",
     "name": "Perfumer",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_183_skgoat",
     "name": "Earthspirit",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_185_frncat",
     "name": "Mousse",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_187_ccheal",
     "name": "Gavial",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_188_helage",
     "name": "Hellagur",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_190_clour",
     "name": "Vermeil",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_192_falco",
     "name": "Plume",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_193_frostl",
     "name": "Frostleaf",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_195_glassb",
     "name": "Istina",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_196_sunbr",
     "name": "Gummy",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_197_poca",
     "name": "Rosa",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_198_blackd",
     "name": "Courier",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_199_yak",
     "name": "Matterhorn",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_201_moeshd",
     "name": "Croissant",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_2013_cerber",
     "name": "Ceobe",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_2014_nian",
     "name": "Nian",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_2015_dusk",
     "name": "Dusk",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_202_demkni",
     "name": "Saria",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_204_platnm",
     "name": "Platinum",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_208_melan",
     "name": "Melantha",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_209_ardign",
     "name": "Cardigan",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_210_stward",
     "name": "Steward",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_211_adnach",
     "name": "Adnachiel",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_212_ansel",
     "name": "Ansel",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_213_mostma",
     "name": "Mostima",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_214_kafka",
     "name": "Kafka",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_215_mantic",
     "name": "Manticore",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_218_cuttle",
     "name": "Andreana",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_219_meteo",
     "name": "Meteorite",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_220_grani",
     "name": "Grani",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_222_bpipe",
     "name": "Bagpipe",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_225_haak",
     "name": "Aak",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_226_hmau",
     "name": "Hung",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_230_savage",
     "name": "Savage",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_235_jesica",
     "name": "Jessica",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_236_rope",
     "name": "Rope",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_237_gravel",
     "name": "Gravel",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_240_wyvern",
     "name": "Vanilla",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_241_panda",
     "name": "FEater",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_242_otter",
     "name": "Mayer",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_243_waaifu",
     "name": "Waai Fu",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_248_mgllan",
     "name": "Magallan",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_250_phatom",
     "name": "Phantom",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_252_bibeak",
     "name": "Bibeak",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_253_greyy",
     "name": "Greyy",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_254_vodfox",
     "name": "Shamare",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_258_podego",
     "name": "Podenco",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_260_durnar",
     "name": "Dur-nar",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_261_sddrag",
     "name": "Reed",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_263_skadi",
     "name": "Skadi",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_264_f12yin",
     "name": "Mountain",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_265_sophia",
     "name": "Whislash",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_271_spikes",
     "name": "Arene",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_272_strong",
     "name": "Jaye",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_274_astesi",
     "name": "Astesia",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_275_breeze",
     "name": "Breeze",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_277_sqrrel",
     "name": "Shaw",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_278_orchid",
     "name": "Orchid",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_279_excu",
     "name": "Executor",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_281_popka",
     "name": "Popukar",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_282_catap",
     "name": "Catapult",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_283_midn",
     "name": "Midnight",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_284_spot",
     "name": "Spot",
     "isCnOnly": false,
     "rarity": 3
   },
   {
+    "id": "char_285_medic2",
+    "name": "Lancet-2",
+    "isCnOnly": false,
+    "rarity": 1
+  },
+  {
+    "id": "char_286_cast3",
+    "name": "Castle-3",
+    "isCnOnly": false,
+    "rarity": 1
+  },
+  {
+    "id": "char_289_gyuki",
     "name": "Matoimaru",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_290_vigna",
     "name": "Vigna",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_291_aglina",
     "name": "Angelina",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_293_thorns",
     "name": "Thorns",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_294_ayer",
     "name": "Ayerscarpe",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_298_susuro",
     "name": "Sussurro",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_301_cutter",
     "name": "Cutter",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_302_glaze",
     "name": "Ambriel",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_304_zebra",
     "name": "Heavyrain",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_306_leizi",
     "name": "Leizi",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_308_swire",
     "name": "Swire",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_311_mudrok",
     "name": "Mudrock",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_325_bison",
     "name": "Bison",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_326_glacus",
     "name": "Glaucus",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_328_cammou",
     "name": "Click",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_332_archet",
     "name": "Archetto",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_333_sidero",
     "name": "Sideroca",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_336_folivo",
     "name": "Scene",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_337_utage",
     "name": "Utage",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_338_iris",
     "name": "Iris",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_340_shwaz",
     "name": "Schwarz",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_343_tknogi",
     "name": "Tsukinogi",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_344_beewax",
     "name": "Beeswax",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_345_folnic",
     "name": "Folinic",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_346_aosta",
     "name": "Aosta",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_347_jaksel",
     "name": "Jackie",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_348_ceylon",
     "name": "Ceylon",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_349_chiave",
     "name": "Chiave",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_350_surtr",
     "name": "Surtr",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_355_ethan",
     "name": "Ethan",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_356_broca",
     "name": "Broca",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_358_lisa",
     "name": "Suzuran",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_362_saga",
     "name": "Saga",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_363_toddi",
     "name": "Toddifons",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_365_aprl",
     "name": "April",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_366_acdrop",
     "name": "Aciddrop",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_367_swllow",
     "name": "GreyThroat",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_369_bena",
+    "name": "Bena",
+    "isCnOnly": true,
+    "rarity": 5
+  },
+  {
+    "id": "char_373_lionhd",
     "name": "Leonhardt",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_376_therex",
+    "name": "Thermal-EX",
+    "isCnOnly": false,
+    "rarity": 1
+  },
+  {
+    "id": "char_378_asbest",
     "name": "Asbestos",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_379_sesa",
     "name": "Sesa",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_381_bubble",
     "name": "Bubble",
     "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_383_snsant",
     "name": "Snowsant",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_385_finlpp",
     "name": "Purestream",
-    "isCnOnly": true,
+    "isCnOnly": false,
     "rarity": 4
   },
   {
+    "id": "char_388_mint",
     "name": "Mint",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_391_rosmon",
     "name": "Rosmontis",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_400_weedy",
     "name": "Weedy",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_401_elysm",
     "name": "Elysium",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_402_tuye",
     "name": "Tuye",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_405_absin",
     "name": "Absinthe",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_411_tomimi",
     "name": "Tomimi",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_415_flint",
     "name": "Flint",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_416_zumama",
     "name": "Eunectes",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_423_blemsh",
     "name": "Blemishine",
     "isCnOnly": false,
     "rarity": 6
   },
   {
+    "id": "char_426_billro",
+    "name": "Carnelian",
+    "isCnOnly": true,
+    "rarity": 6
+  },
+  {
+    "id": "char_436_whispr",
     "name": "Whisperain",
     "isCnOnly": false,
     "rarity": 5
   },
   {
+    "id": "char_440_pinecn",
     "name": "Pinecone",
     "isCnOnly": true,
     "rarity": 4
   },
   {
+    "id": "char_451_robin",
     "name": "Robin",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_452_bstalk",
     "name": "Beanstalk",
     "isCnOnly": true,
     "rarity": 4
   },
   {
+    "id": "char_455_nothin",
     "name": "Mr.Nothing",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_456_ash",
     "name": "Ash",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_457_blitz",
     "name": "Blitz",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_458_rfrost",
     "name": "Frost",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_459_tachak",
     "name": "Tachanka",
     "isCnOnly": true,
     "rarity": 5
   },
   {
+    "id": "char_469_indigo",
+    "name": "Indigo",
+    "isCnOnly": true,
+    "rarity": 4
+  },
+  {
+    "id": "char_472_pasngr",
     "name": "Passenger",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_474_glady",
     "name": "Gladiia",
     "isCnOnly": true,
     "rarity": 6
   },
   {
+    "id": "char_475_akafyu",
     "name": "Akafuyu",
     "isCnOnly": true,
     "rarity": 5
   },
   {
-    "name": "Amiya (Guard)",
+    "id": "char_478_kirara",
+    "name": "Kirara",
     "isCnOnly": true,
+    "rarity": 5
+  },
+  {
+    "id": "char_500_noirc",
+    "name": "Noir Corne",
+    "isCnOnly": false,
+    "rarity": 2
+  },
+  {
+    "id": "char_501_durin",
+    "name": "Durin",
+    "isCnOnly": false,
+    "rarity": 2
+  },
+  {
+    "id": "char_502_nblade",
+    "name": "Yato",
+    "isCnOnly": false,
+    "rarity": 2
+  },
+  {
+    "id": "char_503_rang",
+    "name": "Rangers",
+    "isCnOnly": false,
+    "rarity": 2
+  },
+  {
+    "id": "char_1001_amiya2",
+    "name": "Amiya (Guard)",
+    "isCnOnly": false,
     "rarity": 5
   }
 ]


### PR DESCRIPTION
This PR does two things:
1. Add missing 1* and 2* operators
2. Add the ingame "id" property to each operator entry (e.g. Amiya's ID is `char_002_amiya`)

Note that "Amiya (Guard)" is included now, which we might want to filter out?